### PR TITLE
Remove LICENSE from gitbook

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,13 +1,10 @@
 # Table of contents
 
 * [Stooa][home]
-* [License][license]
 * [Code of conduct][conduct]
 * [How to contribute][contribute]
 
 
 [home]: README.md
-[license]: LICENSE
-[contribute]: CONTRIBUTING.md
 [conduct]: CODE_OF_CONDUCT.md
-[covenant_shield]: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg
+[contribute]: CONTRIBUTING.md


### PR DESCRIPTION
License doesn't render well on Gitbook, also it is not needed to have it there.